### PR TITLE
Cache `is_wsl()` result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsl"
-version = "0.1.0"
+version = "0.2.0"
 description = "Detect if the program is running under Windows Subsystem for Linux"
 authors = ["Hannes Karppila <hannes.karppila@gmail.com>"]
 edition = "2018"
@@ -10,3 +10,6 @@ license = "MIT"
 repository = "https://github.com/Dentosal/wsl-rs"
 keywords = ["wsl", "windows", "run-time", "detection"]
 categories = ["os"]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+ once_cell = "1.13.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,18 @@
 /// Test if the program is running under WSL
 #[cfg(target_os = "linux")]
 pub fn is_wsl() -> bool {
-    if let Ok(b) = std::fs::read("/proc/sys/kernel/osrelease") {
-        if let Ok(s) = std::str::from_utf8(&b) {
-            let a = s.to_ascii_lowercase();
-            return a.contains("microsoft") || a.contains("wsl");
+    use once_cell::sync::OnceCell;
+    static CACHED_RESULT: OnceCell<bool> = OnceCell::new();
+
+    *CACHED_RESULT.get_or_init(|| {
+        if let Ok(b) = std::fs::read("/proc/sys/kernel/osrelease") {
+            if let Ok(s) = std::str::from_utf8(&b) {
+                let a = s.to_ascii_lowercase();
+                return a.contains("microsoft") || a.contains("wsl");
+            }
         }
-    }
-    false
+        false
+    })
 }
 
 /// Test if the program is running under WSL


### PR DESCRIPTION
Hello and thank you for making the `wsl` crate!

This PR uses [`once_cell`](https://lib.rs/crates/once_cell) to cache the result of a `is_wsl()` call, as requested in #3. [We have a motivating use case for this in Nushell](https://github.com/nushell/nushell/issues/6436).

## Considerations

It's not ideal to add a dependency, but `once_cell` is _extremely_ widely used, so much so that [it's already in `std` on nightly](https://github.com/rust-lang/rust/issues/74465). Once it's stabilized, we could update `wsl` to use the stdlib instead of a crate.

## Testing done

Manually confirmed that:
- `wsl` still builds and returns the right result on Linux (WSL) and Windows
- the caching works as expected and the result is only calculated once when `is_wsl()` is called multiple times